### PR TITLE
docs: Move title to rst file

### DIFF
--- a/docs/service.rst
+++ b/docs/service.rst
@@ -1,1 +1,5 @@
+========================
+:mod:`pgtoolkit.service`
+========================
+
 .. automodule:: pgtoolkit.service

--- a/pgtoolkit/service.py
+++ b/pgtoolkit/service.py
@@ -1,10 +1,6 @@
 # coding: utf-8
 
 """
-========================
-:mod:`pgtoolkit.service`
-========================
-
 See `The Connection Service File
 <https://www.postgresql.org/docs/current/static/libpq-pgservice.html>`__ in
 PostgreSQL documentation.


### PR DESCRIPTION
Fixes:

    /home/docs/checkouts/readthedocs.org/user_builds/pgtoolkit/checkouts/latest/docs/contents.rst:6: WARNING: toctree contains reference to document 'service' that doesn't have a title: no link will be generated