### PR TITLE
Editing postgres.conf

### DIFF
--- a/pgtoolkit/_helpers.py
+++ b/pgtoolkit/_helpers.py
@@ -45,6 +45,35 @@ def open_or_stdin(filename, stdin=sys.stdin):
     return fo
 
 
+class PassthroughManager(object):
+    def __init__(self, ret=None):
+        self.ret = ret
+
+    def __enter__(self):
+        return self.ret
+
+    def __exit__(self, *a):
+        pass
+
+
+def open_or_return(fo_or_path, mode='r'):
+    # Returns a context manager around a file-object for fo_or_path. If
+    # fo_or_path is a file-object, the context manager keeps it open. If it's a
+    # path, the file is opened with mode and will be closed upon context exit.
+    # If fo_or_path is None, a ValueError is raised.
+
+    if fo_or_path is None:
+        raise ValueError('No file-like object nor path provided')
+    if isinstance(fo_or_path, string_types):
+        return open(fo_or_path, mode)
+
+    # Skip default file context manager. This allows to always use with
+    # statement and don't care about closing the file. If the file is opened
+    # here, it will be closed properly. Otherwise, it will be kept open thanks
+    # to PassthroughManager.
+    return PassthroughManager(fo_or_path)
+
+
 class Timer(object):
     def __enter__(self):
         self.start = datetime.utcnow()

--- a/pgtoolkit/conf.py
+++ b/pgtoolkit/conf.py
@@ -141,6 +141,22 @@ def parse_value(raw):
                 return raw
 
 
+class Entry(object):
+    # Holds the parsed representation of a configuration entry line.
+    #
+    # This includes the comment.
+
+    def __init__(self, name, value, comment=None, raw_line=None):
+        self.name = name
+        self.value = value
+        self.comment = comment
+        # Store the raw_line to track the position in the list of lines.
+        self.raw_line = raw_line
+
+    def __repr__(self):
+        return '<%s %s=%s>' % (self.__class__.__name__, self.name, self.value)
+
+
 class Configuration(object):
     r"""Holds a parsed configuration.
 
@@ -181,11 +197,11 @@ class Configuration(object):
             m = self._parameter_re.match(line)
             if not m:
                 raise ValueError("Bad line: %r." % raw_line)
-            entry = m.groupdict()
-            entry['value'] = parse_value(entry['value'])
-            entry['raw_line'] = raw_line
-
-            self.entries[entry['name']] = entry
+            kwargs = m.groupdict()
+            kwargs['value'] = parse_value(kwargs['value'])
+            kwargs['raw_line'] = raw_line
+            entry = Entry(**kwargs)
+            self.entries[entry.name] = entry
 
     def __getattr__(self, name):
         try:
@@ -197,7 +213,7 @@ class Configuration(object):
         return self.entries[key]['value']
 
     def as_dict(self):
-        return dict([(k, v['value']) for k, v in self.entries.items()])
+        return dict([(k, v.value) for k, v in self.entries.items()])
 
     def save(self, fo=None):
         """Write configuration to a file.

--- a/pgtoolkit/conf.py
+++ b/pgtoolkit/conf.py
@@ -154,8 +154,10 @@ class Configuration(object):
 
     .. attribute:: path
 
-        Path to a file. Automatically set when calling :fun:`parse` with a path
-        to a file.
+        Path to a file. Automatically set when calling :func:`parse` with a path
+        to a file. This is default target for :meth:`save`.
+
+    .. automethod:: save
 
     """  # noqa
     _parameter_re = re.compile(
@@ -196,6 +198,19 @@ class Configuration(object):
 
     def as_dict(self):
         return dict([(k, v['value']) for k, v in self.entries.items()])
+
+    def save(self, fo=None):
+        """Write configuration to a file.
+
+        Configuration entries order and comments are preserved.
+
+        :param fo: A path or file-like object. Required if :attr:`path` is
+            None.
+
+        """
+        with open_or_return(fo or self.path, mode='w') as fo:
+            for line in self.lines:
+                fo.write(line)
 
 
 def _main(argv):  # pragma: nocover

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,5 +1,6 @@
-from io import StringIO
+from datetime import timedelta
 from textwrap import dedent
+from io import StringIO
 
 import pytest
 
@@ -89,6 +90,30 @@ def test_parser():
 
     with pytest.raises(ValueError):
         parse(['bad_line'])
+
+
+def test_serialize_entry():
+    from pgtoolkit.conf import Entry
+
+    e = Entry(name='grp.setting', value=True)
+
+    assert 'grp.setting' in repr(e)
+    assert 'grp.setting = true' == str(e)
+
+    assert "'2 kB'" == Entry(name='var', value=2048).serialize()
+    assert 'var = 15' == str(Entry(name='var', value=15))
+    assert 'var = 0.1' == str(Entry(name='var', value=.1))
+    assert 'var = enum' == str(Entry(name='var', value='enum'))
+    assert "var = 'sp ced'" == str(Entry(name='var', value='sp ced'))
+    assert r"var = 'quo\'ed'" == str(Entry(name='var', value="quo'ed"))
+
+    assert "'1d'" == Entry('var', value=timedelta(days=1)).serialize()
+    assert "'1h'" == Entry('var', value=timedelta(minutes=60)).serialize()
+    assert "'61 min'" == Entry('var', value=timedelta(minutes=61)).serialize()
+    e = Entry('var', value=timedelta(microseconds=12000))
+    assert "'12 ms'" == e.serialize()
+
+    assert '  # Comment' in str(Entry('var', 1, comment='Comment'))
 
 
 def test_save():

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,3 +1,4 @@
+from io import StringIO
 from textwrap import dedent
 
 import pytest
@@ -88,3 +89,13 @@ def test_parser():
 
     with pytest.raises(ValueError):
         parse(['bad_line'])
+
+
+def test_save():
+    from pgtoolkit.conf import parse
+
+    conf = parse(['listen_addresses = *'])
+    fo = StringIO()
+    conf.save(fo)
+    out = fo.getvalue()
+    assert 'listen_addresses = *' in out

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,3 +1,7 @@
+from io import StringIO
+import pytest
+
+
 def test_open_or_stdin(mocker):
     from pgtoolkit._helpers import open_or_stdin
 
@@ -9,6 +13,27 @@ def test_open_or_stdin(mocker):
     open_.return_value = fo = object()
 
     assert open_or_stdin('toto.conf') is fo
+
+
+def test_open_or_return(mocker):
+    from pgtoolkit._helpers import open_or_return
+
+    # File case.
+    fo = object()
+    with open_or_return(fo) as ret:
+        assert ret is fo
+
+    # Path case
+    open_ = mocker.patch(
+        'pgtoolkit._helpers.open', creates=True)
+    open_.return_value = fo = StringIO()
+
+    with open_or_return('toto.conf') as ret:
+        assert ret is fo
+
+    # None case.
+    with pytest.raises(ValueError):
+        open_or_return(None)
 
 
 def test_timer():


### PR DESCRIPTION
cc @pgiraud & @madtibo 

This PR includes:

- parse path or file-like object with `open_or_return`
- updating in-memory configuration
- serialize scalars in postgresql.conf format
- save to postgresql.conf

This PR does **not** include :

- comment wrapping
- inclusion of file or directories.