### PR TITLE
drop python 2 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,26 +54,9 @@ jobs:
           command: |
             tests/datatests.sh
 
-  unit-py26:
-    docker:
-    - image: dalibo/python26:slim
-      environment:
-        TERM: linux
-        TERMINFO: /etc/terminfo
-    working_directory: /workspace
-    steps:
-      - checkout
-      - restore_cache: *restore_cache
-      - run: *deps
-      - save_cache: *save_cache
-      - run: *unit_tests
-      - run: *script_tests
-
-
 workflows:
   version: 2
   pipeline:
     jobs:
     - unit-py36
-    - unit-py26
     - rpm-centos7

--- a/pgtoolkit/_helpers.py
+++ b/pgtoolkit/_helpers.py
@@ -4,17 +4,6 @@ import sys
 from datetime import timedelta
 
 
-PY2 = sys.version_info < (3,)
-
-if PY2:  # pragma: nocover_py3
-    string_types = (str, unicode)  # noqa
-    unicode = unicode  # noqa
-    bytes = str
-else:  # pragma: nocover_py2
-    string_types = (str,)
-    unicode = str
-
-
 def format_timedelta(delta):
     values = [
         (delta.days, 'd'),
@@ -45,7 +34,7 @@ def open_or_stdin(filename, stdin=sys.stdin):
     return fo
 
 
-class PassthroughManager(object):
+class PassthroughManager:
     def __init__(self, ret=None):
         self.ret = ret
 
@@ -64,7 +53,7 @@ def open_or_return(fo_or_path, mode='r'):
 
     if fo_or_path is None:
         raise ValueError('No file-like object nor path provided')
-    if isinstance(fo_or_path, string_types):
+    if isinstance(fo_or_path, str):
         return open(fo_or_path, mode)
 
     # Skip default file context manager. This allows to always use with
@@ -74,7 +63,7 @@ def open_or_return(fo_or_path, mode='r'):
     return PassthroughManager(fo_or_path)
 
 
-class Timer(object):
+class Timer:
     def __enter__(self):
         self.start = datetime.utcnow()
         return self

--- a/pgtoolkit/conf.py
+++ b/pgtoolkit/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """\
 .. currentmodule:: pgtoolkit.conf
 
@@ -39,15 +38,9 @@ You can use this module to dump a configuration file as JSON object
 """
 
 
-from __future__ import print_function
-
 import json
 from ast import literal_eval
-try:  # pragma: nocover_py26
-    from collections import OrderedDict
-except ImportError:  # pragma: nocover_py3
-    # On python 2.6, order is not preserved
-    OrderedDict = dict
+from collections import OrderedDict
 import re
 import sys
 from datetime import timedelta
@@ -141,7 +134,7 @@ def parse_value(raw):
                 return raw
 
 
-class Entry(object):
+class Entry:
     # Holds the parsed representation of a configuration entry line.
     #
     # This includes the comment.
@@ -208,7 +201,7 @@ class Entry(object):
         return line
 
 
-class Configuration(object):
+class Configuration:
     r"""Holds a parsed configuration.
 
     You can access parameter using attribute or dictionnary syntax.

--- a/pgtoolkit/conf.py
+++ b/pgtoolkit/conf.py
@@ -215,8 +215,8 @@ class Configuration:
     >>> conf['port'] = 5434
     >>> conf.port
     5434
-    >>> conf['pg_stat_statement.min_duration']
-    datetime.timedelta(0, 3)
+    >>> conf['pg_stat_statement.min_duration'].total_seconds()
+    3.0
 
     .. attribute:: path
 

--- a/pgtoolkit/hba.py
+++ b/pgtoolkit/hba.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 """.. currentmodule:: pgtoolkit.hba
 
 This module supports reading, validating, editing and rendering ``pg_hba.conf``
@@ -69,9 +67,6 @@ fit pseudo-column width. If filename is ``-``, stdin is read instead.
 
 """  # noqa
 
-
-from __future__ import print_function
-
 import os
 import shlex
 import sys
@@ -81,7 +76,6 @@ from .errors import ParseError
 from ._helpers import (
     open_or_return,
     open_or_stdin,
-    string_types,
 )
 
 
@@ -90,7 +84,7 @@ class HBAComment(str):
         return '<%s %.32s>' % (self.__class__.__name__, self)
 
 
-class HBARecord(object):
+class HBARecord:
     """Holds a HBA record composed of fields and a comment.
 
     Common fields are accessible through attribute : ``conntype``,
@@ -268,7 +262,7 @@ class HBARecord(object):
         return True
 
 
-class HBA(object):
+class HBA:
     """Represents pg_hba.conf records
 
     .. attribute:: lines
@@ -410,7 +404,7 @@ def parse(file):
         corresponding to the path to the file to open and parse.
     :rtype: :class:`HBA`.
     """
-    if isinstance(file, string_types):
+    if isinstance(file, str):
         with open(file) as fo:
             hba = parse(fo)
             hba.path = file

--- a/pgtoolkit/hba.py
+++ b/pgtoolkit/hba.py
@@ -353,11 +353,11 @@ class HBA:
         if filter is None and not len(attrs.keys()):
             raise ValueError('Attributes dict cannot be empty')
 
-        filter = filter or (lambda l: l.matches(**attrs))
+        filter = filter or (lambda line: line.matches(**attrs))
 
         self.lines = [
-            l for l in self.lines
-            if not (isinstance(l, HBARecord) and filter(l))
+            line for line in self.lines
+            if not (isinstance(line, HBARecord) and filter(line))
         ]
 
     def merge(self, other):

--- a/pgtoolkit/log/__init__.py
+++ b/pgtoolkit/log/__init__.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """\
 .. currentmodule:: pgtoolkit.log
 

--- a/pgtoolkit/log/__main__.py
+++ b/pgtoolkit/log/__main__.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import json
 import logging
 import os

--- a/pgtoolkit/log/parser.py
+++ b/pgtoolkit/log/parser.py
@@ -504,7 +504,7 @@ class Record:
         # Stage 3. Analyze message lines.
 
         self.message = ''.join([
-            l.lstrip('\t').rstrip('\n') for l in self.message_lines
+            line.lstrip('\t').rstrip('\n') for line in self.message_lines
         ])
 
     def as_dict(self):

--- a/pgtoolkit/log/parser.py
+++ b/pgtoolkit/log/parser.py
@@ -1,9 +1,8 @@
-# coding: utf-8
 import re
 from datetime import datetime, timedelta
 
 
-class LogParser(object):
+class LogParser:
     """Log parsing manager
 
     This object gather parsing parameters and trigger parsing logic. When
@@ -142,7 +141,7 @@ class UnknownData(Exception):
         return ''.join(self.lines)
 
 
-class NoopFilters(object):
+class NoopFilters:
     """Basic filter doing nothing.
 
     Filters are grouped in an object to simplify the definition of a filtering
@@ -189,7 +188,7 @@ class NoopFilters(object):
         """
 
 
-class PrefixParser(object):
+class PrefixParser:
     """ Extract record metadata from PostgreSQL log line prefix.
 
     .. automethod:: from_configuration
@@ -323,7 +322,7 @@ class PrefixParser(object):
                 fields[k] = cast(v)
 
 
-class Record(object):
+class Record:
     """Log record object.
 
     Record object stores record fields and implements the different parse

--- a/pgtoolkit/pgpass.py
+++ b/pgtoolkit/pgpass.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 r""".. currentmodule:: pgtoolkit.pgpass
 
 This module provides support for `.pgpass` file format. Here are some
@@ -59,15 +58,12 @@ path as first argument, read it, validate it, sort it and output it in stdout.
 
 """  # noqa
 
-
-from __future__ import print_function
-
 import os
 import sys
 import warnings
 
 from .errors import ParseError
-from ._helpers import open_or_stdin, string_types
+from ._helpers import open_or_stdin
 
 
 def unescape(s, delim):
@@ -145,7 +141,7 @@ class PassComment(str):
             return False
 
 
-class PassEntry(object):
+class PassEntry:
     """Holds a .pgpass entry.
 
     .. automethod:: parse
@@ -266,7 +262,7 @@ class PassEntry(object):
         return True
 
 
-class PassFile(object):
+class PassFile:
     """Holds .pgpass file entries and comments.
 
     .. automethod:: parse
@@ -427,7 +423,7 @@ def parse(file):
         corresponding to the path to the file to open and parse.
     :rtype: :class:`PassFile`
     """
-    if isinstance(file, string_types):
+    if isinstance(file, str):
         with open(file) as fo:
             pgpass = parse(fo)
             pgpass.path = file

--- a/pgtoolkit/service.py
+++ b/pgtoolkit/service.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 """.. currentmodule:: pgtoolkit.service
 
 This module supports reading, validating, editing and rendering ``pg_service``
@@ -90,17 +88,12 @@ comments.
 
 """
 
-from __future__ import print_function
 
-try:
-    from configparser import ConfigParser
-except ImportError:  # pragma: nocover_py3
-    from ConfigParser import ConfigParser
-
+from configparser import ConfigParser
 import os
 import sys
 
-from ._helpers import open_or_stdin, string_types
+from ._helpers import open_or_stdin
 
 
 class Service(dict):
@@ -144,7 +137,7 @@ class Service(dict):
         self[name] = value
 
 
-class ServiceFile(object):
+class ServiceFile:
     """Service file representation, parsing and rendering.
 
     :class:`ServiceFile` is subscriptable. You can access service using
@@ -297,7 +290,7 @@ def parse(file, source=None):
         around equals. pgtoolkit accepts spaces but do not write them.
 
     """
-    if isinstance(file, string_types):
+    if isinstance(file, str):
         with open(file) as fo:
             services = parse(fo, source=source)
             services.path = file

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -2,9 +2,8 @@ codecov
 docutils
 flake8
 pytest
-pytest-capturelog; python_version == '2.6'
 pytest-cov
 pytest-mock
-sphinx; python_version > '2.6'
-sphinx-autobuild; python_version > '2.6'
-sphinx_rtd_theme; python_version > '2.6'
+sphinx
+sphinx-autobuild
+sphinx_rtd_theme

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -3,7 +3,7 @@ YUM_LABS=../../yum-labs
 
 all:
 	$(MAKE) -sC $(YUM_LABS) clean
-	$(MAKE) build-centos7 build-centos6
+	$(MAKE) build-centos7
 
 build-centos%:
 	docker-compose run --rm centos$*

--- a/rpm/build
+++ b/rpm/build
@@ -24,11 +24,13 @@ yum_install() {
 sudo sed -i '/^\[updates\]/,/^gpgkey=/d' /etc/yum.repos.d/CentOS-Base.repo
 
 # Purge previous installation
-if rpm --query --queryformat= python-pgtoolkit ; then
-    sudo yum remove -y python-pgtoolkit
+if rpm --query --queryformat= python3-pgtoolkit ; then
+    sudo yum remove -y python3-pgtoolkit
 fi
 
 rm -rf build/bdist*/rpm
+
+yum_install python3 python3-setuptools
 
 # Build it
 # No --undefine on CentOS 6.
@@ -42,10 +44,10 @@ rpmbuild -bb \
          --define "_sourcedir ${top_srcdir}/dist" \
          rpm/python-pgtoolkit.spec
 version=$(sed -n '/^Version:/{s,.*:\t,,g; p; q}' rpm/python-pgtoolkit.spec)
-rpm=dist/noarch/python-pgtoolkit*${version}*$(rpm --eval '%dist').noarch.rpm
+rpm=dist/noarch/python3-pgtoolkit*${version}*$(rpm --eval '%dist').noarch.rpm
 ln -fs noarch/$(basename $rpm) dist/last_build.rpm
 
 # Test it
 sudo yum install -y $rpm
 cd /
-python -c 'import pgtoolkit'
+python3 -c 'import pgtoolkit'

--- a/rpm/python-pgtoolkit.spec
+++ b/rpm/python-pgtoolkit.spec
@@ -16,6 +16,7 @@ License:	PostgreSQL
 URL:		https://pypi.org/project/pgtoolkit/
 Source0:	https://files.pythonhosted.org/packages/source/%(n=%{srcname}; echo ${n:0:1})/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:	noarch
+BuildRequires:	python3-setuptools
 
 %description
 pgtoolkit provides implementations to manage various file formats in Postgres

--- a/rpm/python-pgtoolkit.spec
+++ b/rpm/python-pgtoolkit.spec
@@ -1,26 +1,11 @@
-%if 0%{?fedora} > 23
-%{!?with_python3:%global with_python3 1}
 %global __ospython3 %{_bindir}/python3
 %{expand: %%global py3ver %(echo `%{__ospython3} -c "import sys; sys.stdout.write(sys.version[:3])"`)}
 %global python3_sitelib %(%{__ospython3} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
-%global __ospython2 %{_bindir}/python2
-%{expand: %%global py2ver %(echo `%{__ospython2} -c "import sys; sys.stdout.write(sys.version[:3])"`)}
-%global python2_sitelib %(%{__ospython2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
-%else
-%{!?with_python3:%global with_python3 0}
-%global __ospython2 %{_bindir}/python2
-%{expand: %%global py2ver %(echo `%{__ospython2} -c "import sys; sys.stdout.write(sys.version[:3])"`)}
-%global python2_sitelib %(%{__ospython2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
-%endif
 
 %global sname pgtoolkit
 %global srcname pgtoolkit
 
-%if 0%{?with_python3}
 Name:		python3-%{sname}
-%else
-Name:		python-%{sname}
-%endif
 # Must point to a released version on PyPI.
 Version:	0.7.3
 Release:	1%{?dist}
@@ -40,32 +25,20 @@ cluster or from libpq. Including pg_hba.conf, logs, .pgpass and pg_service.conf.
 %setup -q -n %{srcname}-%{version}
 
 %build
-%if 0%{?with_python3}
 CFLAGS="%{optflags}" %{__ospython3} setup.py build
-%else
-CFLAGS="%{optflags}" %{__ospython2} setup.py build
-%endif # with_python3
 
 %install
-%if 0%{?with_python3}
 %{__ospython3} setup.py install --skip-build --root %{buildroot}
-%else
-%{__ospython2} setup.py install --skip-build --root %{buildroot}
-%endif # with_python3
 
 
 %files
 %doc README.rst
-%if 0%{?with_python3}
 %{python3_sitelib}/%{sname}-%{version}-py%{py3ver}.egg-info
 %dir %{python3_sitelib}/%{sname}
 %{python3_sitelib}/%{sname}/*
-%else
-%{python2_sitelib}/%{sname}-%{version}-py%{py2ver}.egg-info
-%dir %{python2_sitelib}/%{sname}
-%{python2_sitelib}/%{sname}/*
-%endif
 
 %changelog
+* Tue Jul 28 2020 Denis Laxalde <denis.laxalde@dalibo.com> - 1:0.8.0-1
+- Only build the Python3 version.
 * Tue Aug 28 2018 Étienne BERSAC <etienne.bersac@dalibo.com> - 1:0.0.1b1-1
 - Initial packaging.

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,9 +2,6 @@
 long_description = file: README.rst
 classifiers =
     License :: OSI Approved
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.6
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.6
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,6 @@ long_description = file: README.rst
 classifiers =
     License :: OSI Approved
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
 
 [tool:pytest]
 addopts = -vvv --strict --showlocals --cov=pgtoolkit --cov-report=term-missing --doctest-modules

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,4 @@
-try:
-    # Use setuptools for bdist_wheel and other extension.
-    from setuptools import setup
-except ImportError:
-    # Let's try distutils for rpm build/install.
-    from distutils.core import setup
+from setuptools import setup
 
 
 metadatas = dict(

--- a/tests/datatests.sh
+++ b/tests/datatests.sh
@@ -1,13 +1,5 @@
 #!/bin/bash -eux
 
-is_python26() {
-        python --version |& grep -qF 2.6
-}
-
-is_python3() {
-        python --version |& grep -qF 3.
-}
-
 python -m pgtoolkit.hba data/pg_hba.conf
 ! (python -m pgtoolkit.hba data/pg_hba_bad.conf && exit 1)
 
@@ -18,12 +10,7 @@ python -m pgtoolkit.service data/pg_service.conf
 ! (python -m pgtoolkit.service data/pg_service_bad.conf && exit 1)
 
 logscript=pgtoolkit.log
-if is_python26 ; then
-        logscript=${logscript}.__main__
-fi
 python -m $logscript '%m [%p]: [%l-1] app=%a,db=%d%q,client=%h,user=%u ' data/postgresql.log
-if is_python3 ; then
-        scripts/profile-log
-fi
+scripts/profile-log
 
 python -m pgtoolkit.conf data/postgres.conf

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -4,17 +4,6 @@ from io import StringIO
 
 import pytest
 
-from pgtoolkit._helpers import PY2
-
-
-if PY2:
-    class UnicodeIO(StringIO):
-        def write(self, chunk):
-            if isinstance(chunk, str):
-                chunk = chunk.decode('utf-8')
-            return super(UnicodeIO, self).write(chunk)
-    StringIO = UnicodeIO
-
 
 def test_parse_value():
     from pgtoolkit.conf import parse_value

--- a/tests/test_hba.py
+++ b/tests/test_hba.py
@@ -263,5 +263,5 @@ def test_merge():
     expected_hba = parse(expected_lines)
 
     def r(hba):
-        return os.linesep.join([str(l) for l in hba.lines])
+        return os.linesep.join([str(line) for line in hba.lines])
     assert r(hba) == r(expected_hba)

--- a/tests/test_pass.py
+++ b/tests/test_pass.py
@@ -184,8 +184,8 @@ def test_remove():
     pgpass.remove(port=5432, username='postgres')
     assert 5 == len(pgpass.lines)
 
-    def filter(l):
-        return l.username == 'postgres'
+    def filter(line):
+        return line.username == 'postgres'
 
     pgpass = parse(lines)
     pgpass.remove(filter=filter)


### PR DESCRIPTION
As far as Dalibo is concerned, there is no longer any downstream project using pgtoolkit on python2.

The last commit fixes a flake8 error which happens with recent version of flake8 and thus gets triggered only now in CI.