### PR TITLE
adjust packaging following python2 support drop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,5 @@ release:
 	git tag $(VERSION)
 	git push $(GIT_UPSTREAM) master
 	git push --tags $(GIT_UPSTREAM)
-	python setup.py sdist bdist_wheel --universal
+	python setup.py sdist bdist_wheel
 	twine upload dist/pgtoolkit-$(VERSION).tar.gz dist/pgtoolkit-$(VERSION)-*.whl

--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,6 @@ if __name__ == '__main__':
     setup(
         packages=['pgtoolkit'],
         package_data={'pgtoolkit': ['py.typed']},
+        python_requires=">=3.6",
         **metadatas
     )


### PR DESCRIPTION
* We cannot ship universal wheel anymore.
* Let's also `python_requires = ">=3.6"` to prevent pip from installing the project on older Python versions (esp. py2)