### PR TITLE
Declare a conntype attribute to HBARecord

### DIFF
--- a/pgtoolkit/hba.py
+++ b/pgtoolkit/hba.py
@@ -162,6 +162,7 @@ class HBARecord:
         options = base_options + auth_options  # type: ignore
         return cls(options, comment=comment)
 
+    conntype: Optional[str]
     databases: List[str]
     users: List[str]
 


### PR DESCRIPTION
This is commonly passed in 'values' when building the object and is also
documented.