### PR TITLE
Configure flake8 better

### DIFF
--- a/pgtoolkit/log/parser.py
+++ b/pgtoolkit/log/parser.py
@@ -138,8 +138,8 @@ def parse_isodatetime(raw: str) -> datetime:
 def parse_epoch(raw: str) -> datetime:
     epoch, ms = raw.split('.')
     return (
-        datetime.utcfromtimestamp(int(epoch)) +
-        timedelta(microseconds=int(ms))
+        datetime.utcfromtimestamp(int(epoch))
+        + timedelta(microseconds=int(ms))
     )
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,13 @@ classifiers =
     License :: OSI Approved
     Programming Language :: Python :: 3
 
+[flake8]
+doctests = True
+select = B,C,E,F,W,T4,B9
+ignore =
+  E226, # missing whitespace around arithmetic operator
+  W503, # line break before binary operator
+
 [tool:pytest]
 addopts = -vvv --strict --showlocals --cov=pgtoolkit --cov-report=term-missing --doctest-modules
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -80,8 +80,8 @@ def test_parser():
     assert '*' == conf.listen_addresses
     assert 5432 == conf.port
     assert (
-        conf.primary_conninfo ==
-        "host=''example.com'' port=5432 dbname=mydb connect_timeout=10"
+        conf.primary_conninfo
+        == "host=''example.com'' port=5432 dbname=mydb connect_timeout=10"
     )
     assert 'without equals' == conf.bonjour
     assert 248 * 1024 * 1024 == conf['shared.buffers']


### PR DESCRIPTION
We now require that line break happens before the binary operator, as advised
by PEP8. We also select more checks by default, but ignore E226 for the
moment.