### PR TITLE
Strip leading '#' from comment in configuration value

### DIFF
--- a/pgtoolkit/conf.py
+++ b/pgtoolkit/conf.py
@@ -367,6 +367,9 @@ class Configuration:
             kwargs = m.groupdict()
             name = kwargs.pop('name')
             value = parse_value(kwargs.pop('value'))
+            comment = kwargs['comment']
+            if comment is not None:
+                kwargs['comment'] = comment.lstrip('#').lstrip()
             try:
                 include_type = IncludeType[name]
             except KeyError:

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -100,6 +100,10 @@ def test_parser():
     conf = parse(lines)
 
     assert '*' == conf.listen_addresses
+    assert (
+        str(conf.entries['listen_addresses'])
+        == "listen_addresses = '*'  # comma-separated list of addresses;"
+    )
     assert 5432 == conf.port
     assert (
         conf.primary_conninfo


### PR DESCRIPTION
Since we re-insert the '#' in Entry.__str__(), we need to strip it when parsing
the raw line.