### PR TITLE
Handle redundant configuration entries, keep the last one

### DIFF
--- a/pgtoolkit/conf.py
+++ b/pgtoolkit/conf.py
@@ -473,6 +473,9 @@ class Configuration:
                 assert isinstance(value, str), type(value)
                 includes.append((pathlib.Path(value), include_type))
             else:
+                if name in self:
+                    entry = self.entries[name]
+                    self.lines.remove(entry.raw_line)
                 self.entries[name] = Entry(
                     name=name,
                     value=value,

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -139,6 +139,18 @@ def test_parser():
         parse(['bad_line'])
 
 
+def test_configuration_multiple_entries():
+    from pgtoolkit.conf import Configuration
+
+    conf = Configuration()
+    conf.parse(["port=5432", "port=5433  # the real one!!"])
+    assert conf["port"] == 5433
+    fo = StringIO()
+    conf.save(fo)
+    out = fo.getvalue().strip()
+    assert out == "port=5433  # the real one!!"
+
+
 def test_parser_includes_require_a_file_path():
     from pgtoolkit.conf import parse
 


### PR DESCRIPTION
We parse postgresql.conf with multiple entries for the same parameter name, we
need to only keep the last occurrence.