### PR TITLE
Correctly handle overwrite by commented entry in conf parsing

### DIFF
--- a/pgtoolkit/conf.py
+++ b/pgtoolkit/conf.py
@@ -513,6 +513,15 @@ class Configuration:
                 comment = kwargs["comment"]
                 if comment is not None:
                     kwargs["comment"] = comment.lstrip("#").lstrip()
+                if commented:
+                    # Only overwrite a previous entry if it is commented.
+                    try:
+                        existing_entry = self.entries[name]
+                    except KeyError:
+                        pass
+                    else:
+                        if not existing_entry.commented:
+                            continue
                 self.entries[name] = Entry(
                     name=name,
                     value=value,

--- a/tests/data/postgres-my.conf
+++ b/tests/data/postgres-my.conf
@@ -1,4 +1,5 @@
 cluster_name = 'pgtoolkit'
+authentication_timeout = 2min
 include_if_exists = 'missing.conf'
 include_if_exists = 'postgres-my-my.conf'
 mymy = false

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -88,7 +88,9 @@ def test_parser():
     bonjour 'without equals'
     # bonjour_name = ''		# defaults to the computer name
     shared.buffers = 248MB
+    #authentication_timeout = 2min      # will be overwritten by the one below
     #authentication_timeout = 1min		# 1s-600s
+    # port = 5454  # commented value does not override previous (uncommented) one
     """
     ).splitlines(
         True
@@ -172,6 +174,7 @@ def test_parser_includes():
     fpath = pathlib.Path(__file__).parent / "data" / "postgres.conf"
     conf = parse(str(fpath))
     assert conf.as_dict() == {
+        "authentication_timeout": timedelta(seconds=120),
         "autovacuum_work_mem": -1,
         "bonjour": False,
         "bonsoir": True,


### PR DESCRIPTION
We only overwrite an existing entry when a new one with a same name is
encountered if the new one is not commented or the old is commented.