### PR TITLE
Fix ordering of PassEntry w.r.t. to 'port' value type

### DIFF
--- a/pgtoolkit/pgpass.py
+++ b/pgtoolkit/pgpass.py
@@ -250,10 +250,10 @@ class PassEntry:
             [str(x).replace("\\", r"\\").replace(":", r"\:") for x in self.as_tuple()]
         )
 
-    def as_tuple(self) -> Tuple[str, Union[int, str], str, str, str]:
+    def as_tuple(self) -> Tuple[str, str, str, str, str]:
         return (
             self.hostname,
-            self.port,
+            str(self.port),
             self.database,
             self.username,
             self.password,

--- a/tests/test_pass.py
+++ b/tests/test_pass.py
@@ -55,10 +55,14 @@ def test_compare():
     a = PassEntry.parse(":*:*:*:confidentiel")
     b = PassEntry.parse("hostname:*:*:*:otherpassword")
     c = PassEntry.parse("hostname:5442:*:username:otherpassword")
+    d = PassEntry("hostname", "5442", "*", "username", "otherpassword")
+    e = PassEntry("hostname", "5443", "*", "username", "otherpassword")
 
     assert a < b
     assert c < b
     assert a != b
+    assert c == d
+    assert c < e
 
     assert [c, a, b] == sorted([a, b, c])
 


### PR DESCRIPTION
By previously return either an int or a string as 'port' value in
PassEntry.as_tuple() we could get a TypeError when trying to compare str and
int values in sort_key() method. We now convert the port field into a string
int as_tuple().