### PR TITLE
Handle pgpass with only comments in sort()

### DIFF
--- a/pgtoolkit/pgpass.py
+++ b/pgtoolkit/pgpass.py
@@ -380,11 +380,15 @@ class PassFile:
             entries.append((line, comments))
             comments = []
 
-        entries.sort()
         self.lines[:] = []
-        for entry, comments in entries:
+        if not entries and comments:
+            # no entry, only comments
             self.lines.extend(comments)
-            self.lines.append(entry)
+        else:
+            entries.sort()
+            for entry, comments in entries:
+                self.lines.extend(comments)
+                self.lines.append(entry)
 
     def save(self, fo: Optional[IO[str]] = None) -> None:
         """Save entries and comment in a file.

--- a/tests/test_pass.py
+++ b/tests/test_pass.py
@@ -126,6 +126,11 @@ def test_parse_lines(tmp_path):
         "h2:*:*:postgres:confidentiel",
     ]
 
+    header = "#hostname:port:database:username:password"
+    pgpass = parse([header])
+    pgpass.sort()
+    assert pgpass.lines == [header]
+
 
 @pytest.mark.parametrize("pathtype", [str, Path])
 def test_parse_file(pathtype, tmp_path):


### PR DESCRIPTION
Previously, when the password file was only composed of comments, these were
discarded upon .sort() call.