### PR TITLE
Add a GH workflow to publish to PyPI upon tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install
+        run: python -m pip install setuptools wheel twine
+      - name: Build
+        run: |
+          python setup.py check
+          python setup.py sdist bdist_wheel
+          python -m twine check dist/*
+      - name: Publish
+        run: python -m twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
This is untested, we'll see with next tag if this works. (I've added the token to repository secrets.)