### PR TITLE
Prevent hba parsing error with backslash in record

### DIFF
--- a/tests/test_hba.py
+++ b/tests/test_hba.py
@@ -130,6 +130,19 @@ def test_parse_record_with_double_quoting():
     assert record.radiussecrets == '""secret one"",""secret two""'
 
 
+def test_parse_record_blank_in_quotes():
+    from pgtoolkit.hba import HBARecord
+
+    record = HBARecord.parse(
+        r"host all all all ldap ldapserver=ldap.example.net"
+        r' ldapbasedn="dc=example, dc=net"'
+        r' ldapsearchfilter="(|(uid=$username)(mail=$username))"'
+    )
+    assert record.ldapserver == "ldap.example.net"
+    assert record.ldapbasedn == "dc=example, dc=net"
+    assert record.ldapsearchfilter == "(|(uid=$username)(mail=$username))"
+
+
 def test_hba(mocker):
     from pgtoolkit.hba import parse
 

--- a/tests/test_hba.py
+++ b/tests/test_hba.py
@@ -121,6 +121,15 @@ def test_parse_record_with_backslash():
     assert record.ldapprefix == "DOMAINE\\"
 
 
+def test_parse_record_with_double_quoting():
+    from pgtoolkit.hba import HBARecord
+
+    record = HBARecord.parse(
+        r'host all all all radius radiusservers="server1,server2" radiussecrets="""secret one"",""secret two"""'
+    )
+    assert record.radiussecrets == '""secret one"",""secret two""'
+
+
 def test_hba(mocker):
     from pgtoolkit.hba import parse
 

--- a/tests/test_hba.py
+++ b/tests/test_hba.py
@@ -112,6 +112,15 @@ def test_parse_invalid_connection_type():
         HBARecord.parse("pif    all     all")
 
 
+def test_parse_record_with_backslash():
+    from pgtoolkit.hba import HBARecord
+
+    record = HBARecord.parse(
+        r'host all all all ldap ldapserver=host.local ldapprefix="DOMAINE\"'
+    )
+    assert record.ldapprefix == "DOMAINE\\"
+
+
 def test_hba(mocker):
     from pgtoolkit.hba import parse
 


### PR DESCRIPTION
shlex.split fails with "No closing quotation"when a backslash is directly followed by a double-quote