### PR TITLE
Add a test for parsing HBA records with blanks in quotes

### DIFF
--- a/tests/test_hba.py
+++ b/tests/test_hba.py
@@ -112,6 +112,19 @@ def test_parse_invalid_connection_type():
         HBARecord.parse("pif    all     all")
 
 
+def test_parse_record_blank_in_quotes():
+    from pgtoolkit.hba import HBARecord
+
+    record = HBARecord.parse(
+        r"host all all all ldap ldapserver=ldap.example.net"
+        r' ldapbasedn="dc=example, dc=net"'
+        r' ldapsearchfilter="(|(uid=$username)(mail=$username))"'
+    )
+    assert record.ldapserver == "ldap.example.net"
+    assert record.ldapbasedn == "dc=example, dc=net"
+    assert record.ldapsearchfilter == "(|(uid=$username)(mail=$username))"
+
+
 def test_hba(mocker):
     from pgtoolkit.hba import parse
 


### PR DESCRIPTION
Example taken from chapter "21.10. LDAP Authentication" of PostgreSQL
documentation.