### PR TITLE
Only bypass write of empty pgpass if it was already empty

### DIFF
--- a/pgtoolkit/pgpass.py
+++ b/pgtoolkit/pgpass.py
@@ -398,8 +398,6 @@ class PassFile:
 
         :param fo: a file-like object. Is not required if :attr:`path` is set.
         """
-        if not self.lines:
-            return
 
         def _write(fo: IO[str], lines: Iterable[object]) -> None:
             for line in lines:
@@ -410,6 +408,8 @@ class PassFile:
         elif self.path:
             fpath = Path(self.path)
             if not fpath.exists():
+                if not self.lines:
+                    return
                 fpath.touch(mode=0o600)
             with open(self.path, "w") as fo:
                 _write(fo, self.lines)

--- a/tests/test_pass.py
+++ b/tests/test_pass.py
@@ -160,6 +160,14 @@ def test_edit(tmp_path):
     assert fpath.read_text() == "# commented\n"
 
     with edit(fpath) as passfile:
+        del passfile.lines[:]
+    assert fpath.read_text() == ""
+
+    with edit(fpath) as passfile:
+        passfile.lines.append(PassComment("# commented"))
+    assert fpath.read_text() == "# commented\n"
+
+    with edit(fpath) as passfile:
         passfile.lines.extend(
             [
                 PassEntry("*", "5443", "*", "username", "otherpassword"),


### PR DESCRIPTION
This fixes up commit aa90611456aec0d8a0d82b91b6e329af4b051dbd which wrongly
bypassed write of the pgpass when it had no entry thus breaking a use case
where passfile's entries would be cleared, as evidenced in added tests here.

We thus move the check for empty 'lines' after the check for non-existence of
the file path.

(Should fix failed pipeline at https://gitlab.com/dalibo/pglift/-/merge_requests/362)