### PR TITLE
Only try to parse commented configuration entry with an =

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,7 @@ master_doc = "contents"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/pgtoolkit/conf.py
+++ b/pgtoolkit/conf.py
@@ -492,7 +492,12 @@ class Configuration:
                 continue
             commented = False
             if line.startswith("#"):
-                # Try to parse the uncommented line.
+                # Try to parse the commented line as a commented parameter,
+                # but only if in the form of 'name = value' since we cannot
+                # discriminate a commented sentence (with whitespaces) from a
+                # commented parameter in the form of 'name value'.
+                if "=" not in line:
+                    continue
                 line = line.lstrip("#").lstrip()
                 m = self._parameter_re.match(line)
                 if not m:

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import pathlib
+import sys
 
 from setuptools import find_packages, setup
 
@@ -6,6 +7,8 @@ here = pathlib.Path(__file__).parent
 
 with (here / "README.rst").open("r", encoding="utf-8") as fo:
     long_description = fo.read()
+
+py36 = sys.version_info < (3, 7)
 
 metadatas = dict(
     name="pgtoolkit",
@@ -25,7 +28,7 @@ metadatas = dict(
         "Topic :: Database",
     ],
     use_scm_version=True,
-    setup_requires=["setuptools_scm"],
+    setup_requires=["setuptools_scm < 7" if py36 else "setuptools_scm"],
     install_requires=[
         "typing_extensions",
     ],

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -78,6 +78,18 @@ def test_parser():
 
     lines = dedent(
         """\
+    # This file consists of lines of the form:
+    #
+    #   name = value
+    #
+    # (The "=" is optional.)  Whitespace may be used.  Comments are introduced with
+    # "#" anywhere on a line.  The complete list of parameter names and allowed
+    # values can be found in the PostgreSQL documentation.
+    #
+    # The commented-out settings shown in this file represent the default values.
+    # Re-commenting a setting is NOT sufficient to revert it to the default value;
+    # you need to reload the server.
+
     # - Connection Settings -
     listen_addresses = '*'                  # comma-separated list of addresses;
                             # defaults to 'localhost'; use '*' for all
@@ -122,6 +134,12 @@ def test_parser():
         str(conf.entries["authentication_timeout"])
         == "#authentication_timeout = '1 min'  # 1s-600s"
     )
+
+    assert [(e.name, e.value) for e in conf if e.commented] == [
+        ("name", "value"),
+        ("bonjour_name", ""),
+        ("authentication_timeout", timedelta(seconds=60)),
+    ]
 
     dict_ = conf.as_dict()
     assert "*" == dict_["listen_addresses"]


### PR DESCRIPTION
It seems not possible to distinguish a commented parameter without an = sign
from a plain sentence, as shown in extra test case where the default header of
postgresql.conf is inserted. Therefore, we only try to parse commented lines as
commented parameters if there is an equal sign.