### PR TITLE
Don't inline doc comments in flake8 configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,10 +5,14 @@ source = pgtoolkit
 doctests = True
 select = B,C,E,F,W,T4,B9
 ignore =
-  E203, # whitespace before ':'
-  E501, # line too long
-  E226, # missing whitespace around arithmetic operator
-  W503, # line break before binary operator
+  # whitespace before ':'
+  E203,
+  # line too long
+  E501,
+  # missing whitespace around arithmetic operator
+  E226,
+  # line break before binary operator
+  W503,
 
 [tool:pytest]
 addopts = -vvv --strict-markers --showlocals --doctest-modules


### PR DESCRIPTION
With Flake8 6.0.0 inline comments were producing the following error: ValueError: Error code '#' supplied to 'ignore' option does not match '^[A-Z]{1,3}[0-9]{0,3}$'