### PR TITLE
Fix connection service serialization wrongly including 'name' parameter

### DIFF
--- a/pgtoolkit/service.py
+++ b/pgtoolkit/service.py
@@ -120,9 +120,11 @@ class Service(dict[str, Parameter]):
     'mydb'
     >>> myservice.user = 'myuser'
     >>> list(sorted(myservice.items()))
-    [('dbname', 'mydb'), ('host', 'myhost'), ('name', 'myservice'), ('user', 'myuser')]
+    [('dbname', 'mydb'), ('host', 'myhost'), ('user', 'myuser')]
 
     """  # noqa
+
+    name: str
 
     def __init__(
         self,
@@ -131,7 +133,7 @@ class Service(dict[str, Parameter]):
         **extra: Parameter,
     ) -> None:
         super().__init__()
-        self.name = name
+        super().__setattr__("name", name)
         self.update(parameters or {})
         self.update(extra)
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -78,18 +78,14 @@ def test_render():
     assert raw == "\n".join(
         [
             "[service0]",
-            "name=service0",
             "port=5432",
             "",
             "[service1]",
-            "name=service1",
             "host=myhost",
             "",
             "",
         ]
     )
-    # TODO: In ^, 'name=' entries should not be there,
-    # see https://github.com/dalibo/pgtoolkit/issues/118
 
 
 def test_sysconfdir(mocker):


### PR DESCRIPTION
Fix #118 