### PR TITLE
Fix "docs" CI job with docutils >= 0.21

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,5 +16,5 @@ jobs:
         run: python -m pip install -r requirements-ci.txt -e .
       - name: Check documentation
         run: |
-          python setup.py --long-description | rst2html.py --strict >/dev/null
+          python setup.py --long-description | rst2html --strict >/dev/null
           make -C docs clean html

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,7 +1,7 @@
 black>=24.2.0
 check-manifest
 codecov
-docutils
+docutils>=0.21.0
 flake8
 isort
 mypy>=0.982


### PR DESCRIPTION
The rst2html.py script not longer exists; use rst2html executable instead.