### PR TITLE
Only append uncommented entries when editing pgconf

### DIFF
--- a/pgtoolkit/conf.py
+++ b/pgtoolkit/conf.py
@@ -629,13 +629,14 @@ class Configuration:
         try:
             lineno = self.lines.index(old_line)
         except ValueError:
-            msg = (
-                f"entry {key!r} not directly found in {self.path or 'parsed content'}"
-                " (it might be defined in an included file),"
-                " appending a new line to set requested value"
-            )
-            warn(msg, UserWarning)
-            self.lines.append(entry.raw_line)
+            if not entry.commented:
+                msg = (
+                    f"entry {key!r} not directly found in {self.path or 'parsed content'}"
+                    " (it might be defined in an included file),"
+                    " appending a new line to set requested value"
+                )
+                warn(msg, UserWarning)
+                self.lines.append(entry.raw_line)
         else:
             self.lines[lineno : lineno + 1] = [entry.raw_line]
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -481,23 +481,24 @@ def test_edit_included_value(tmp_path: pathlib.Path) -> None:
     from pgtoolkit.conf import parse
 
     included = tmp_path / "included.conf"
-    included.write_text("included = true\n")
+    included.write_text("foo = true\nbar= off\n")
     base = tmp_path / "postgresql.conf"
     lines = ["bonjour = on", f"include = {included}", "cluster_name=test"]
     base.write_text("\n".join(lines) + "\n")
 
     conf = parse(base)
-    with pytest.warns(UserWarning, match="entry 'included' not directly found"):
+    with pytest.warns(UserWarning, match="entry 'foo' not directly found"):
         with conf.edit() as entries:
-            entries["included"].value = False
+            entries["foo"].value = False
+            entries["bar"].commented = True
 
     out = tmp_path / "postgresql-new.conf"
     conf.save(out)
     newlines = out.read_text().splitlines()
-    assert newlines == lines + ["included = off"]
+    assert newlines == lines + ["foo = off"]
 
     conf = parse(out)
-    assert conf["included"] is False
+    assert conf["foo"] is False
 
 
 def test_configuration_iter():


### PR DESCRIPTION
Follow-up commit 7604544e1c170dc8855facd8532543a9630f24bc. With the test case as is now, and the previous code, we'd see a '# bar = off' entry in updated file, which does not make sense as the (uncommented) value from included file would apply. Accordingly, we only append the new entry if uncommented.