### PR TITLE
Upgrade typing syntax

### DIFF
--- a/pgtoolkit/_helpers.py
+++ b/pgtoolkit/_helpers.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import json
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import IO, Any, Generic, NoReturn, Optional, TypeVar, Union, overload
+from typing import IO, Any, Generic, NoReturn, TypeVar, overload
 
 
 def format_timedelta(delta: timedelta) -> str:
@@ -22,7 +24,7 @@ def format_timedelta(delta: timedelta) -> str:
 
 
 class JSONDateEncoder(json.JSONEncoder):
-    def default(self, obj: Union[timedelta, datetime, object]) -> Any:
+    def default(self, obj: timedelta | datetime | object) -> Any:
         if isinstance(obj, datetime):
             return obj.isoformat()
         elif isinstance(obj, timedelta):
@@ -71,8 +73,8 @@ def open_or_return(
 
 
 def open_or_return(
-    fo_or_path: Optional[Union[str, Path, IO[str]]], mode: str = "r"
-) -> Union[IO[str], PassthroughManager[IO[str]]]:
+    fo_or_path: str | Path | IO[str] | None, mode: str = "r"
+) -> IO[str] | PassthroughManager[IO[str]]:
     # Returns a context manager around a file-object for fo_or_path. If
     # fo_or_path is a file-object, the context manager keeps it open. If it's a
     # path, the file is opened with mode and will be closed upon context exit.
@@ -93,7 +95,7 @@ def open_or_return(
 
 
 class Timer:
-    def __enter__(self) -> "Timer":
+    def __enter__(self) -> Timer:
         self.start = datetime.now(timezone.utc)
         return self
 

--- a/pgtoolkit/errors.py
+++ b/pgtoolkit/errors.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class ParseError(Exception):
     def __init__(self, lineno: int, line: str, message: str) -> None:
         super().__init__(message)

--- a/pgtoolkit/log/__init__.py
+++ b/pgtoolkit/log/__init__.py
@@ -97,6 +97,8 @@ You can use this module to dump logs as JSON using the following usage::
 
 """  # noqa
 
+from __future__ import annotations
+
 from .parser import LogParser, NoopFilters, PrefixParser, Record, UnknownData, parse
 
 __all__ = [

--- a/pgtoolkit/log/__main__.py
+++ b/pgtoolkit/log/__main__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import bdb
 import json
 import logging

--- a/pgtoolkit/service.py
+++ b/pgtoolkit/service.py
@@ -88,11 +88,13 @@ comments.
 
 """
 
+from __future__ import annotations
+
 import os
 import sys
 from collections.abc import Iterable, MutableMapping
 from configparser import ConfigParser
-from typing import IO, Optional, Union
+from typing import IO, Union
 
 from ._helpers import open_or_stdin
 
@@ -129,7 +131,7 @@ class Service(dict[str, Parameter]):
     def __init__(
         self,
         name: str,
-        parameters: Optional[dict[str, Parameter]] = None,
+        parameters: dict[str, Parameter] | None = None,
         **extra: Parameter,
     ) -> None:
         super().__init__()
@@ -163,7 +165,7 @@ class ServiceFile:
         path to a file. :meth:`save` will write to this file if set.
     """
 
-    path: Optional[str]
+    path: str | None
 
     _CONVERTERS = {
         "port": int,
@@ -195,7 +197,7 @@ class ServiceFile:
         for parameter, value in service.items():
             self.config.set(service.name, parameter, str(value))
 
-    def parse(self, fo: Iterable[str], source: Optional[str] = None) -> None:
+    def parse(self, fo: Iterable[str], source: str | None = None) -> None:
         """Add service from a service file.
 
         This method is strictly the same as :func:`parse`. It’s the method
@@ -203,7 +205,7 @@ class ServiceFile:
         """
         self.config.read_file(fo, source=source)
 
-    def save(self, fo: Optional[IO[str]] = None) -> None:
+    def save(self, fo: IO[str] | None = None) -> None:
         """Writes services in ``fo`` file-like object.
 
         :param fo: a file-like object. Is not required if :attr:`path` is set.
@@ -242,7 +244,7 @@ def guess_sysconfdir(environ: MutableMapping[str, str] = os.environ) -> str:
     raise Exception("Can't find sysconfdir")
 
 
-def find(environ: Optional[MutableMapping[str, str]] = None) -> str:
+def find(environ: MutableMapping[str, str] | None = None) -> str:
     """Find service file.
 
     :param dict environ: Dict of environment variables.
@@ -284,7 +286,7 @@ def find(environ: Optional[MutableMapping[str, str]] = None) -> str:
     raise Exception("Can't find pg_service file.")
 
 
-def parse(file: Union[str, Iterable[str]], source: Optional[str] = None) -> ServiceFile:
+def parse(file: str | Iterable[str], source: str | None = None) -> ServiceFile:
     """Parse a service file.
 
     :param file: a file-object as returned by open or a string corresponding to


### PR DESCRIPTION
By using `from __future__ import annotations`, we can remove Union and Optional imports from typing.