### PR TITLE
Use importlib.metadata instead pkg_resources in docs configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import pkg_resources
+import importlib.metadata
 
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
@@ -22,10 +22,9 @@ author = "Dalibo"
 copyright = "2018, Dalibo Labs"
 
 # The full version, including alpha/beta/rc tags
-release = pkg_resources.get_distribution(project).version
-parsed_version = pkg_resources.parse_version(release)
+release = importlib.metadata.version(project)
 # The short X.Y version
-version = parsed_version.base_version
+version = ".".join(release.split(".")[:2])
 
 
 # -- General configuration ---------------------------------------------------

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 addopts = -vvv --strict-markers --showlocals --doctest-modules --ignore pgtoolkit/ctl.py
 asyncio_mode = strict
+asyncio_default_fixture_loop_scope = function
 filterwarnings =
   error

--- a/tests/test_ctl_func.py
+++ b/tests/test_ctl_func.py
@@ -16,7 +16,7 @@ def pgctl() -> ctl.PGCtl:
         pytest.skip(str(e))
 
 
-@pytest_asyncio.fixture(scope="module")
+@pytest_asyncio.fixture(loop_scope="module")
 async def apgctl() -> ctl.AsyncPGCtl:
     try:
         return await ctl.AsyncPGCtl.get()
@@ -51,7 +51,7 @@ def initdb(tmp_path_factory, pgctl: ctl.PGCtl) -> tuple[Path, Path, Path]:
     return datadir, waldir, pid_path
 
 
-@pytest_asyncio.fixture(scope="module")
+@pytest_asyncio.fixture(loop_scope="module")
 async def ainitdb(tmp_path_factory, apgctl: ctl.AsyncPGCtl) -> tuple[Path, Path, Path]:
     datadir = tmp_path_factory.mktemp("data")
     waldir = tmp_path_factory.mktemp("wal")

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ skip_install = true
 allowlist_externals =
   ./tests/datatests.sh
 commands =
-  pytest -ra --cov --cov-report=term-missing pgtoolkit/ tests/
+  pytest -ra --cov --cov-report=term-missing {posargs}
   ./tests/datatests.sh
 deps =
   ci: codecov

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ allowlist_externals =
   ./tests/datatests.sh
 commands =
   pytest -ra --cov --cov-report=term-missing {posargs}
-  ./tests/datatests.sh
+  ci: ./tests/datatests.sh
 deps =
   ci: codecov
 extras =


### PR DESCRIPTION
And a couple of minor changes regarding tests and CI.