### PR TITLE
Fix broken upload to Codecov

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,4 +25,6 @@ jobs:
           tox -v -e tests-ci
       - name: Upload coverage to Codecov
         if: ${{ matrix.python-version == '3.12' }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.egg-info/
 *.pyc
-.coverage
+coverage.xml
 .eggs
 .mypy_cache/
 .pybuild

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ skip_install = true
 allowlist_externals =
   ./tests/datatests.sh
 commands =
-  pytest -ra --cov --cov-report=term-missing {posargs}
+  pytest -ra --cov --cov-report=term-missing --cov-report=xml {posargs}
   ci: ./tests/datatests.sh
 deps =
   ci: codecov


### PR DESCRIPTION
Codecov now requires a TOKEN to upload results.
We update the version of the github action and use the token added in the project settings.

We write the coverage report as XML in a file for codecov upload to be happy. With the default .coverage file, codecov reports a "no coverage file found" error.

Fixes  #140 